### PR TITLE
Fix: Fallback to empty, non-null password for SSH Remote shutdown

### DIFF
--- a/app/src/main/java/de/florianisme/wakeonlan/shutdown/ShutdownExecutor.java
+++ b/app/src/main/java/de/florianisme/wakeonlan/shutdown/ShutdownExecutor.java
@@ -26,7 +26,7 @@ public class ShutdownExecutor {
     public static void shutdownDevice(Device device, ShutdownExecutorListener shutdownExecutorListener) {
         Optional<ShutdownModel> optionalShutdownModel = ShutdownModelFactory.fromDevice(device);
 
-        if (!optionalShutdownModel.isPresent()) {
+        if (optionalShutdownModel.isEmpty()) {
             Log.w(ShutdownExecutor.class.getSimpleName(), "Can not shutdown device. Not all required fields were set");
             shutdownExecutorListener.onGeneralError(new IllegalArgumentException("Can not shutdown device. Not all required fields were set"), null);
             return;

--- a/app/src/main/java/de/florianisme/wakeonlan/shutdown/ShutdownModelFactory.java
+++ b/app/src/main/java/de/florianisme/wakeonlan/shutdown/ShutdownModelFactory.java
@@ -17,18 +17,18 @@ public class ShutdownModelFactory {
         String address = getValueOrFallback(device.sshAddress, device.statusIp);
         int port = getSshPortOrFallback(device.sshPort);
         String username = getValueOrFallback(device.sshUsername, null);
-        String password = getValueOrFallback(device.sshPassword, null);
+        String password = getValueOrFallback(device.sshPassword, "");
         String command = getValueOrFallback(device.sshCommand, null);
 
-        if (allRequiredFieldsSet(shutdownEnabled, address, username, password, command)) {
+        if (allRequiredFieldsSet(shutdownEnabled, address, username, command)) {
             return Optional.of(new ShutdownModel(address, port, username, password, command));
         }
 
         return Optional.empty();
     }
 
-    private static boolean allRequiredFieldsSet(boolean shutdownEnabled, String address, String username, String password, String command) {
-        return shutdownEnabled && address != null && username != null && password != null && command != null;
+    private static boolean allRequiredFieldsSet(boolean shutdownEnabled, String address, String username, String command) {
+        return shutdownEnabled && address != null && username != null && command != null;
     }
 
     @Nullable
@@ -36,10 +36,8 @@ public class ShutdownModelFactory {
         if (!Strings.isNullOrEmpty(value)) {
             return value;
         }
-        if (!Strings.isNullOrEmpty(fallback)) {
-            return fallback;
-        }
-        return null;
+
+        return fallback;
     }
 
     private static Integer getSshPortOrFallback(@Nullable Integer value) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -96,7 +96,7 @@
     <string name="test_shutdown_error_execution_timeout">Ausführung des Kommandos \"%1$s\" dauerte zu lange oder sudo Passwort-Aufforderung wurde gestartet</string>
     <string name="test_shutdown_error_unknown_host">Unbekannter Hostname \"%1$s\"</string>
     <string name="add_device_status_ip_helper">Onlinestatus des Geräts wird regelmäßig unter dieser Adresse per Ping-Befehl abgefragt</string>
-    <string name="add_device_shutdown_explanation">Nutzt SSH um sich am Zielsystem anzumelden und über das entsprechende Kommando herunterzufahren.\nFunktioniert nur auf Systemen, auf denen Linux betrieben wird.</string>
+    <string name="add_device_shutdown_explanation">Nutzt SSH um sich am Zielsystem anzumelden und über das entsprechende Kommando herunterzufahren.</string>
     <string name="add_device_error_port_invalid">Ungültiger Port</string>
     <string name="local_network_permission_denied_title">Berechtigung erforderlich</string>
     <string name="local_network_permission_denied_message">Wake on Lan benötigt die Berechtigung für das lokale Netzwerk, um Magic Packets an deine Geräte zu senden. Ohne diese Berechtigung funktioniert das Aufwecken von Geräten nicht.\n\nBitte erteile die Berechtigung für das lokale Netzwerk in den App-Einstellungen.</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -22,7 +22,7 @@
     <string name="add_device_autofill_broadcast">自动获取广播地址</string>
     <string name="add_device_secure_on">安全网络唤醒密码（可选）</string>
     <string name="add_device_shutdown">远程关机</string>
-    <string name="add_device_shutdown_explanation">使用 SSH 登录设备，并执行指定的关机命令。\n此功能仅在 Linux 上测试过。</string>
+    <string name="add_device_shutdown_explanation">使用 SSH 登录设备，并执行指定的关机命令。</string>
     <string name="add_device_shutdown_enable">启用远程关机</string>
     <string name="add_device_shutdown_ip">SSH 地址</string>
     <string name="add_device_shutdown_port">SSH 端口</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="add_device_autofill_broadcast">Autofill Broadcast Address</string>
     <string name="add_device_secure_on">SecureOn Password (optional)</string>
     <string name="add_device_shutdown">Remote Shutdown</string>
-    <string name="add_device_shutdown_explanation">Uses SSH to log into the device and execute the specified shutdown command.\nThis feature only works on machines running Linux</string>
+    <string name="add_device_shutdown_explanation">Uses SSH to log into the device and execute the specified shutdown command.</string>
     <string name="add_device_shutdown_enable">Enable Remote Shutdown</string>
     <string name="add_device_shutdown_ip">SSH Address</string>
     <string name="add_device_shutdown_port">SSH Port</string>


### PR DESCRIPTION
Closes #75 